### PR TITLE
Fix conditional blocks and some typo errors

### DIFF
--- a/careful_rm.alias.sh
+++ b/careful_rm.alias.sh
@@ -39,11 +39,11 @@ if hash python 2>/dev/null; then
     # Try to get another version if the system version is ancient
     if [[ _pyver -lt 26 ]]; then
         _PY=$(command -v python)
-    fi
-    _pyver=$(${_PY} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-    if [[ _pyver -lt 26 ]]; then
-        # Failed try second pass
-        unset _PY
+        _pyver=$(${_PY} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+        if [[ _pyver -lt 26 ]]; then
+            # Failed try second pass
+            unset _PY
+        fi
     fi
 fi
 

--- a/careful_rm.alias.sh
+++ b/careful_rm.alias.sh
@@ -59,13 +59,13 @@ if [ ! -x $_PY ]; then
             fi
         fi
     done
-fi
 
-# Final check
-if [ ! -x $_PY ]; then
-    echo "No python found!! careful_rm will not work"
-    return 1
-    exit 1
+    # Final check
+    if [ ! -x $_PY ]; then
+        echo "No python found!! careful_rm will not work"
+        return 1
+        exit 1
+    fi
 fi
 
 # Only use our careful_rm if it exists, if not, try for a version on the

--- a/careful_rm.alias.sh
+++ b/careful_rm.alias.sh
@@ -37,10 +37,10 @@ if hash python 2>/dev/null; then
     declare -i _pyver
     _pyver=$(${_PY} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
     # Try to get another version if the system version is ancient
-    if [[ _pyver -lt 26 ]]; then
+    if [[ _pyver -le 26 ]]; then
         _PY=$(command -v python)
         _pyver=$(${_PY} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-        if [[ _pyver -lt 26 ]]; then
+        if [[ _pyver -le 26 ]]; then
             # Failed try second pass
             unset _PY
         fi
@@ -53,7 +53,7 @@ if [ ! -x $_PY ]; then
     for _pth in "${pos_paths[@]}"; do
         if [ -x $_pth ]; then
             _pyver=$(${_pth} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-            if [[ _pyver -ge 26 ]]; then
+            if [[ _pyver -gt 26 ]]; then
                 _PY="$_pth"
                 break
             fi

--- a/careful_rm.alias.sh
+++ b/careful_rm.alias.sh
@@ -52,8 +52,8 @@ if [ ! -x $_PY ]; then
     _pos_paths=('/usr/local/bin/python3' '/usr/bin/python3' '/usr/local/bin/python' '/usr/bin/python' '/bin/python3' '/bin/python')
     for _pth in "${pos_paths[@]}"; do
         if [ -x $_pth ]; then
-            _pyver=$(${_PY} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-            if [[ _pyver -lt 26 ]]; then
+            _pyver=$(${_pth} --version 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+            if [[ _pyver -ge 26 ]]; then
                 _PY="$_pth"
                 break
             fi


### PR DESCRIPTION
- Conditional blocks in `careful_rm.alias.sh` has been optimized. 
- Some typo errors have been fixed in the `Second pass`
- `Final check` has been merged into `Second pass`. Cause `Final check` is only for those failed `Second pass` and redundant for those passed `Second pass`.
- Python version check has been fixed as what is told in `README.md`: `Python > 2.6`, not `Python >= 2.6`